### PR TITLE
Add precovid timeperiod

### DIFF
--- a/analysis/investigate_consultation_codes.R
+++ b/analysis/investigate_consultation_codes.R
@@ -8,6 +8,7 @@ library(readr)
 library(tidyr)
 library(stringr)
 library(fs)
+library(purrr)
 
 # Read file paths of all datasets
 consultation_dataset_paths <- dir_ls(

--- a/analysis/summarise_consultation_dataset.R
+++ b/analysis/summarise_consultation_dataset.R
@@ -5,6 +5,7 @@ library(magrittr)
 library(dplyr)
 library(readr)
 library(tidyr)
+library(purrr)
 
 # Read file paths of all datasets
 consultation_dataset_paths <- fs::dir_ls(

--- a/analysis/summarise_consultation_dataset.R
+++ b/analysis/summarise_consultation_dataset.R
@@ -6,32 +6,47 @@ library(dplyr)
 library(readr)
 library(tidyr)
 
-# Read arrow dataset and assign to df
-df_20200401_to_20210331 <- arrow::read_feather(here::here("output", "consultation_dataset_2020-04-01_to_2021-03-31.arrow"))
+# Read file paths of all datasets
+consultation_dataset_paths <- fs::dir_ls(
+  path = "output/",
+  glob = "*consultation_dataset_*.arrow$"
+)
+
+# Define regex that extracts the date range from the filename
+regex_get_dates <- "\\d{4}-\\d{2}-\\d{2}_to_\\d{4}-\\d{2}-\\d{2}"
+
+# Load all datasets and read dates from file names
+consultation_datasets <- consultation_dataset_paths %>%
+  purrr::map(arrow::read_feather) %>%
+  dplyr::bind_rows(.id = "file_name") %>%
+  dplyr::mutate(file_name = stringr::str_extract(file_name, regex_get_dates)) %>%
+  tidyr::separate(file_name, c("start_date", "end_date"), sep = "_to_")
 
 # Count sum and has (yes/no) of consultations grouped by age group
 # We could add more variables to group by here, e.g., ethnicity or sex
-df_summary <- df_20200401_to_20210331 %>% 
-  dplyr::group_by(age_greater_equal_65) %>%
-  dplyr::summarise(n_sum_f2f = sum(count_f2f_consultation, na.rm = TRUE),
-                   n_sum_virtual = sum(count_virtual_consultation, na.rm = TRUE),
-                   n_has_f2f = sum(has_f2f_consultation, na.rm = TRUE),
-                   n_has_virtual = sum(has_virtual_consultation, na.rm = TRUE)) %>%
-  dplyr::mutate(start_date = "2020-04-01",
-                end_date = "2021-03-31")
-
-# Pivot data longer so it is easier for further data manipulations or visualisations
-df_summary <- df_summary %>%
-  pivot_longer(cols = c(n_sum_f2f, n_sum_virtual, n_has_f2f, n_has_virtual),
-               names_to = c("summary_type", "consultation_type"),
-               values_to = "value", names_sep = "_(?=f2f|virtual)")
+df_summary <- consultation_datasets %>%
+  dplyr::group_by(start_date, end_date, age_greater_equal_65) %>%
+  dplyr::summarise(
+    n_sum_f2f = sum(count_f2f_consultation, na.rm = TRUE),
+    n_sum_virtual = sum(count_virtual_consultation, na.rm = TRUE),
+    n_has_f2f = sum(has_f2f_consultation, na.rm = TRUE),
+    n_has_virtual = sum(has_virtual_consultation, na.rm = TRUE)
+  ) %>%
+  pivot_longer(
+    cols = c(n_sum_f2f, n_sum_virtual, n_has_f2f, n_has_virtual),
+    names_to = c("summary_type", "consultation_type"),
+    values_to = "value", names_sep = "_(?=f2f|virtual)"
+  )
 
 # Apply disclosure controls
-# Remove values lower or equal 7 and round to nearest 10
+# Redact values lower or equal 7 and round all other values to nearest 10
 df_summary <- df_summary %>%
-  mutate(value = case_when(value <= 7 ~ NA_real_,
-                           TRUE ~ round(value, -1)))
+  mutate(value = case_when(
+    value <= 7 ~ NA_real_,
+    TRUE ~ round(value, -1)
+  ))
 
 # Write data
+# Convert all NAs to show "(Redacted)"
 fs::dir_create(here::here("output", "data"))
-write_csv(df_summary, here::here("output", "data", "summary_consultation_dataset.csv"))
+write_csv(df_summary, here::here("output", "data", "summary_consultation_dataset.csv"), na = "(Redacted)")

--- a/analysis/visualise_consultation_dataset.R
+++ b/analysis/visualise_consultation_dataset.R
@@ -5,37 +5,47 @@ library(magrittr)
 library(dplyr)
 library(ggplot2)
 library(tidyr)
+library(fs)
 
 # Create output directory for figures
-fs::dir_create(here::here("output", "figures"))
+dir_create(here("output", "figures"))
 
 # Read csv summary dataset
-df_summary <- readr::read_csv(here::here("output", "data", "summary_consultation_dataset.csv"))
+df_summary <- read_csv(here("output", "data", "summary_consultation_dataset.csv"),
+  na = "(Redacted)",
+  col_types = list(value = "i")
+)
 
 # Create figure with sum of all consultations (this counts multiple consultations per patient)
-plot_n_sum_consultation_by_age <- df_summary %>% 
+plot_n_sum_consultation_by_age <- df_summary %>%
   filter(summary_type == "n_sum") %>%
   ggplot(aes(x = start_date, y = value, fill = consultation_type)) +
-    geom_bar(stat = "identity", position = position_dodge()) +
-    labs(x = NULL, 
-         y = "Count of all consultations",
-         fill = "Type of consultation") +
-    facet_wrap(~factor(age_greater_equal_65, 
-                       levels = c(FALSE, TRUE), 
-                       labels = c("Age > 18 and < 65", "Age >= 65")))
+  geom_bar(stat = "identity", position = position_dodge()) +
+  labs(
+    x = NULL,
+    y = "Count of all consultations",
+    fill = "Type of consultation"
+  ) +
+  facet_wrap(~ factor(age_greater_equal_65,
+    levels = c(FALSE, TRUE),
+    labels = c("Age > 18 and < 65", "Age >= 65")
+  ))
 
-ggsave(here::here("output", "figures", "figure_n_sum_consultation_by_age.png"))
+ggsave(here("output", "figures", "figure_n_sum_consultation_by_age.png"))
 
 # Create figure with sum of all patients that had consultations
-plot_n_has_consultation_by_age <- df_summary %>% 
+plot_n_has_consultation_by_age <- df_summary %>%
   filter(summary_type == "n_has") %>%
   ggplot(aes(x = start_date, y = value, fill = consultation_type)) +
-    geom_bar(stat = "identity", position = position_dodge()) +
-    labs(x = NULL, 
-         y = "Count of patients with consultations",
-         fill = "Type of consultation") +
-    facet_wrap(~factor(age_greater_equal_65, 
-                       levels = c(FALSE, TRUE), 
-                       labels = c("Age > 18 and < 65", "Age >= 65")))
+  geom_bar(stat = "identity", position = position_dodge()) +
+  labs(
+    x = NULL,
+    y = "Count of patients with consultations",
+    fill = "Type of consultation"
+  ) +
+  facet_wrap(~ factor(age_greater_equal_65,
+    levels = c(FALSE, TRUE),
+    labels = c("Age > 18 and < 65", "Age >= 65")
+  ))
 
-ggsave(here::here("output", "figures", "figure_n_has_consultation_by_age.png"))
+ggsave(here("output", "figures", "figure_n_has_consultation_by_age.png"))

--- a/project.yaml
+++ b/project.yaml
@@ -5,6 +5,18 @@ expectations:
 
 actions:
 
+  generate_consultation_dataset_2019-04-01_to_2020-03-31:
+    run: >
+      ehrql:v0
+        generate-dataset analysis/dataset_definition.py
+        --output output/consultation_dataset_2019-04-01_to_2020-03-31.arrow
+        --
+        --start-date "2019-04-01"
+        --end-date "2020-03-31"
+    outputs:
+      highly_sensitive:
+        study_population: output/consultation_dataset_2019-04-01_to_2020-03-31.arrow
+
   generate_consultation_dataset_2020-04-01_to_2021-03-31:
     run: >
       ehrql:v0
@@ -17,12 +29,10 @@ actions:
       highly_sensitive:
         study_population: output/consultation_dataset_2020-04-01_to_2021-03-31.arrow
 
-
-
   summarise_consultation_datasets:
     run: >
       r:latest analysis/summarise_consultation_dataset.R
-    needs: [generate_consultation_dataset_2020-04-01_to_2021-03-31]
+    needs: [generate_consultation_dataset_2019-04-01_to_2020-03-31, generate_consultation_dataset_2020-04-01_to_2021-03-31]
     outputs:
       moderately_sensitive:
         measure_csv: output/data/summary_consultation_dataset.csv


### PR DESCRIPTION
This adds a lot of the things we talked about yesterday:

1. I added a new action with a precovid time period to the `project.yaml`
2. The R scripts summarising the consultation counts and codes now load both of the timeframes and read the dates from the file name (I briefly mentioned this when @AbodunrinAminu-Manchester asked why I add the dates to the file names)
3. The R script for the visualisation didnt need a lot of adaptations (hopefully the way I wrote the ggplot scripts recognises the different time periods)

I also improved the R code style using the [styler](https://styler.r-lib.org/) package. 