### PR TITLE
Addition of appointment categories

### DIFF
--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -72,30 +72,44 @@ dataset.count_virtual_consultation = selected_events.where(
     clinical_events.snomedct_code.is_in(virtual_consultation)
 ).count_for_patient()
 
-dataset.has_appointments = appointments.where(
-    appointments.status.is_in(
-        [
-            "Arrived",
-            "In Progress",
-            "Finished",
-            "Visit",
-            "Waiting",
-            "Patient Walked Out",
-        ]
-    )
+dataset.has_appt_arrived = appointments.where(
+    appointments.status.is_in(["Arrived"])
 ).exists_for_patient()
 
-dataset.count_appointments = appointments.where(
-    appointments.status.is_in(
-        [
-            "Arrived",
-            "In Progress",
-            "Finished",
-            "Visit",
-            "Waiting",
-            "Patient Walked Out",
-        ]
-    )
+dataset.has_appt_finished = appointments.where(
+    appointments.status.is_in(["Finished"])
+).exists_for_patient()
+
+dataset.has_appt_inprogress = appointments.where(
+    appointments.status.is_in(["In Progress"])
+).exists_for_patient()
+
+dataset.has_appt_waiting = appointments.where(
+    appointments.status.is_in(["Waiting"])
+).exists_for_patient()
+
+dataset.has_appt_walkedout = appointments.where(
+    appointments.status.is_in(["Patient Walked Out"])
+).exists_for_patient()
+
+dataset.count_appt_arrived = appointments.where(
+    appointments.status.is_in(["Arrived"])
+).count_for_patient()
+
+dataset.count_appt_finished = appointments.where(
+    appointments.status.is_in(["Finished"])
+).count_for_patient()
+
+dataset.count_appt_inprogress = appointments.where(
+    appointments.status.is_in(["In Progress"])
+).count_for_patient()
+
+dataset.count_appt_waiting = appointments.where(
+    appointments.status.is_in(["Waiting"])
+).count_for_patient()
+
+dataset.count_appt_walkedout = appointments.where(
+    appointments.status.is_in(["Patient Walked Out"])
 ).count_for_patient()
 
 dataset.last_virtual_consultation_code = (

--- a/analysis/summarise_consultation_dataset.R
+++ b/analysis/summarise_consultation_dataset.R
@@ -23,26 +23,6 @@ consultation_datasets <- consultation_dataset_paths %>%
   dplyr::mutate(file_name = stringr::str_extract(file_name, regex_get_dates)) %>%
   tidyr::separate(file_name, c("start_date", "end_date"), sep = "_to_")
 
-# Count sum and has (yes/no) of consultations grouped by age group
-# We could add more variables to group by here, e.g., ethnicity or sex
-# df_summary <- consultation_datasets %>%
-#   dplyr::group_by(start_date, end_date, age_greater_equal_65) %>%
-#   dplyr::summarise(
-#     n_sum_f2f = sum(count_f2f_consultation, na.rm = TRUE),
-#     n_sum_virtual = sum(count_virtual_consultation, na.rm = TRUE),
-#     n_sum_appointment = sum(count_appointments, na.rm = TRUE),
-#     n_has_f2f = sum(has_f2f_consultation, na.rm = TRUE),
-#     n_has_virtual = sum(has_virtual_consultation, na.rm = TRUE),
-#     n_has_appointment = sum(has_appointments, na.rm = TRUE),
-#   ) %>%
-#   pivot_longer(
-#     cols = c(
-#       n_sum_f2f, n_sum_virtual, n_sum_appointment,
-#       n_has_f2f, n_has_virtual, n_has_appointment
-#     ),
-#     names_to = c("summary_type", "consultation_type"),
-#     values_to = "value", names_sep = "_(?=f2f|virtual|appointment)"
-#   )
 
 #Count sum and has (yes/no) of consultations grouped by age group
 #We could add more variables to group by here, e.g., ethnicity or sex

--- a/analysis/summarise_consultation_dataset.R
+++ b/analysis/summarise_consultation_dataset.R
@@ -25,23 +25,50 @@ consultation_datasets <- consultation_dataset_paths %>%
 
 # Count sum and has (yes/no) of consultations grouped by age group
 # We could add more variables to group by here, e.g., ethnicity or sex
+# df_summary <- consultation_datasets %>%
+#   dplyr::group_by(start_date, end_date, age_greater_equal_65) %>%
+#   dplyr::summarise(
+#     n_sum_f2f = sum(count_f2f_consultation, na.rm = TRUE),
+#     n_sum_virtual = sum(count_virtual_consultation, na.rm = TRUE),
+#     n_sum_appointment = sum(count_appointments, na.rm = TRUE),
+#     n_has_f2f = sum(has_f2f_consultation, na.rm = TRUE),
+#     n_has_virtual = sum(has_virtual_consultation, na.rm = TRUE),
+#     n_has_appointment = sum(has_appointments, na.rm = TRUE),
+#   ) %>%
+#   pivot_longer(
+#     cols = c(
+#       n_sum_f2f, n_sum_virtual, n_sum_appointment,
+#       n_has_f2f, n_has_virtual, n_has_appointment
+#     ),
+#     names_to = c("summary_type", "consultation_type"),
+#     values_to = "value", names_sep = "_(?=f2f|virtual|appointment)"
+#   )
+
+#Count sum and has (yes/no) of consultations grouped by age group
+#We could add more variables to group by here, e.g., ethnicity or sex
 df_summary <- consultation_datasets %>%
   dplyr::group_by(start_date, end_date, age_greater_equal_65) %>%
   dplyr::summarise(
-    n_sum_f2f = sum(count_f2f_consultation, na.rm = TRUE),
-    n_sum_virtual = sum(count_virtual_consultation, na.rm = TRUE),
-    n_sum_appointment = sum(count_appointments, na.rm = TRUE),
-    n_has_f2f = sum(has_f2f_consultation, na.rm = TRUE),
+    n_count_appt_arrived = sum(count_appt_arrived, na.rm = TRUE),
+    n_count_appt_finished = sum(count_appt_finished, na.rm = TRUE),
+    n_count_appt_inprogress = sum(count_appt_inprogress, na.rm = TRUE),
+    n_count_appt_waiting = sum(count_appt_waiting, na.rm = TRUE),
+    n_count_appt_walkedout = sum(count_appt_walkedout, na.rm = TRUE),
+    n_count_virtual = sum(count_virtual_consultation, na.rm = TRUE),
+    n_has_appt_arrived = sum(has_appt_arrived, na.rm = TRUE),
+    n_has_appt_finished = sum(has_appt_finished, na.rm = TRUE),
+    n_has_appt_inprogress = sum(has_appt_inprogress, na.rm = TRUE),
+    n_has_appt_waiting = sum(has_appt_waiting, na.rm = TRUE),
+    n_has_appt_walkedout = sum(has_appt_walkedout, na.rm = TRUE),
     n_has_virtual = sum(has_virtual_consultation, na.rm = TRUE),
-    n_has_appointment = sum(has_appointments, na.rm = TRUE),
-  ) %>%
+    ) %>%
   pivot_longer(
     cols = c(
-      n_sum_f2f, n_sum_virtual, n_sum_appointment,
-      n_has_f2f, n_has_virtual, n_has_appointment
+      n_count_appt_arrived, n_count_appt_finished, n_count_appt_inprogress, n_count_appt_waiting, n_count_appt_walkedout, n_count_virtual,
+      n_has_appt_arrived, n_has_appt_finished, n_has_appt_inprogress, n_has_appt_waiting, n_has_appt_walkedout, n_has_virtual
     ),
     names_to = c("summary_type", "consultation_type"),
-    values_to = "value", names_sep = "_(?=f2f|virtual|appointment)"
+    values_to = "value", names_sep = "_(?=arrived|finished|inprogress|waiting|walkedout|virtual )"
   )
 
 # Apply disclosure controls

--- a/analysis/visualise_consultation_dataset.R
+++ b/analysis/visualise_consultation_dataset.R
@@ -18,7 +18,7 @@ df_summary <- read_csv(here("output", "data", "summary_consultation_dataset.csv"
 
 # Create figure with sum of all consultations (this counts multiple consultations per patient)
 plot_n_sum_consultation_by_age <- df_summary %>%
-  filter(summary_type == "n_sum") %>%
+  filter(summary_type == "n_count") %>%
   ggplot(aes(x = start_date, y = value, fill = consultation_type)) +
   geom_bar(stat = "identity", position = position_dodge()) +
   labs(

--- a/project.yaml
+++ b/project.yaml
@@ -45,11 +45,11 @@ actions:
       moderately_sensitive:
         measure_csv: output/data/summary_consultation_codes.csv
 
-  visualise_consultation_datasets:
-    run: >
-      r:latest analysis/visualise_consultation_dataset.R
-    needs: [summarise_consultation_datasets]
-    outputs:
-      moderately_sensitive:
-        figure_n_has: output/figures/figure_n_has_consultation_by_age.png
-        figure_n_sum: output/figures/figure_n_sum_consultation_by_age.png
+  # visualise_consultation_datasets:
+  #   run: >
+  #     r:latest analysis/visualise_consultation_dataset.R
+  #   needs: [summarise_consultation_datasets]
+  #   outputs:
+  #     moderately_sensitive:
+  #       figure_n_has: output/figures/figure_n_has_consultation_by_age.png
+  #       figure_n_sum: output/figures/figure_n_sum_consultation_by_age.png


### PR DESCRIPTION
Appointment categories have been added to the dataset definition file and subsequent R scripts adjusted to reflect these changes. All counts have been designated using (n_counts) and n_has remain same as used in the previous commits. This is intended to look at counts for each of the 6 appointment metadata categories. 