### PR TITLE
Add monthly measures

### DIFF
--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -53,6 +53,23 @@ dataset.last_virtual_consultation_code = (
     .snomedct_code
 )
 
+# f2f (face to face) consultations identified through clinical codes
+dataset.has_f2f_consultation = selected_events.where(
+    clinical_events.snomedct_code.is_in(f2f_consultation)
+).exists_for_patient()
+
+# Count number of f2f that a patient had
+dataset.count_f2f_consultation = selected_events.where(
+    clinical_events.snomedct_code.is_in(virtual_consultation)
+).count_for_patient()
+
+dataset.last_f2f_consultation_code = (
+    selected_events.where(clinical_events.snomedct_code.is_in(f2f_consultation))
+    .sort_by(clinical_events.date)
+    .last_for_patient()
+    .snomedct_code
+)
+
 # Appointments identified through the appointments table
 # Get all appointments with a seen date
 appointments_with_seen_date = appointments.where(

--- a/analysis/measures_definition.py
+++ b/analysis/measures_definition.py
@@ -64,18 +64,7 @@ last_f2f_consultation_code = (
 # Get all appointments with a seen date
 appointments_with_seen_date = appointments.where(
     appointments.seen_date <= INTERVAL.end_date,
-).where(
-    appointments.status.is_in(
-        [
-            "Arrived",
-            "In Progress",
-            "Finished",
-            "Visit",
-            "Waiting",
-            "Patient Walked Out",
-        ]
-    )
-)
+).where(appointments.status.is_in(["Finished"]))
 
 # Count number of appointments with a seen date in the time period
 count_appointment = appointments_with_seen_date.count_for_patient()
@@ -129,26 +118,14 @@ ethnicity = case(
 )
 
 # Define population to be registered and above 18 years old
-denominator = (has_registration & (age > 18))
+denominator = has_registration & (age > 18)
 
 # Define measure
 measures.define_measure(
     name="virtual_consultations",
     numerator=has_virtual_consultation,
     denominator=denominator,
-    group_by={
-        "age_greater_equal_65": age_greater_equal_65
-    },
-    intervals=months(6).starting_on("2020-04-01"),
-)
-
-measures.define_measure(
-    name="f2f_consultations",
-    numerator=has_f2f_consultation,
-    denominator=denominator,
-    group_by={
-        "age_greater_equal_65": age_greater_equal_65
-    },
+    group_by={"age_greater_equal_65": age_greater_equal_65},
     intervals=months(6).starting_on("2020-04-01"),
 )
 
@@ -156,8 +133,6 @@ measures.define_measure(
     name="appointments",
     numerator=has_appointment,
     denominator=denominator,
-    group_by={
-        "age_greater_equal_65": age_greater_equal_65
-    },
+    group_by={"age_greater_equal_65": age_greater_equal_65},
     intervals=months(6).starting_on("2020-04-01"),
 )

--- a/analysis/measures_definition.py
+++ b/analysis/measures_definition.py
@@ -1,6 +1,4 @@
-from argparse import ArgumentParser
-import datetime
-from ehrql import create_dataset, case, when
+from ehrql import INTERVAL, create_measures, case, when, months
 
 from ehrql.tables.beta.tpp import (
     clinical_events,
@@ -16,37 +14,29 @@ from codelists import (
     ethnicity_codelist,
 )
 
-# Get start and end date from project.yaml
-parser = ArgumentParser()
-parser.add_argument("--start-date", type=datetime.date.fromisoformat)
-parser.add_argument("--end-date", type=datetime.date.fromisoformat)
-args = parser.parse_args()
-start_date = args.start_date
-end_date = args.end_date
-
 # Instantiate dataset
-dataset = create_dataset()
+measures = create_measures()
 
 # Extract clinical events that fall between our start and end date
 # for further use in variable definitions below
 selected_events = clinical_events.where(
-    clinical_events.date.is_on_or_between(start_date, end_date)
+    clinical_events.date.is_on_or_between(INTERVAL.start_date, INTERVAL.end_date)
 )
 
 # Virtual consultations identified through clinical codes
 # Check if a patient has a clinical code in the time period defined
 # above (selected_events) that are in the virtual_consultation codelist
-dataset.has_virtual_consultation = selected_events.where(
+has_virtual_consultation = selected_events.where(
     clinical_events.snomedct_code.is_in(virtual_consultation)
 ).exists_for_patient()
 
 # Count number of virtual_consultation that a patient had
 # in the time period defined above (selected_events)
-dataset.count_virtual_consultation = selected_events.where(
+count_virtual_consultation = selected_events.where(
     clinical_events.snomedct_code.is_in(virtual_consultation)
 ).count_for_patient()
 
-dataset.last_virtual_consultation_code = (
+last_virtual_consultation_code = (
     selected_events.where(clinical_events.snomedct_code.is_in(virtual_consultation))
     .sort_by(clinical_events.date)
     .last_for_patient()
@@ -56,7 +46,7 @@ dataset.last_virtual_consultation_code = (
 # Appointments identified through the appointments table
 # Get all appointments with a seen date
 appointments_with_seen_date = appointments.where(
-    appointments.seen_date <= end_date
+    appointments.seen_date <= INTERVAL.end_date,
 ).where(
     appointments.status.is_in(
         [
@@ -71,27 +61,27 @@ appointments_with_seen_date = appointments.where(
 )
 
 # Count number of appointments with a seen date in the time period
-dataset.count_appointment = appointments_with_seen_date.count_for_patient()
+count_appointment = appointments_with_seen_date.count_for_patient()
 # Specify if a patient had (True/False) an appointment with a seen date
-dataset.has_appointment = appointments_with_seen_date.exists_for_patient()
+has_appointment = appointments_with_seen_date.exists_for_patient()
 
 # Demographic variables and other patient characteristics
 # Define variable that checks if a patients is registered at the start date
 has_registration = practice_registrations.for_patient_on(
-    start_date
+    INTERVAL.start_date
 ).exists_for_patient()
 
-dataset.age = patients.age_on(start_date)
-dataset.age_greater_equal_65 = dataset.age >= 65
+age = patients.age_on(INTERVAL.start_date)
+age_greater_equal_65 = age >= 65
 
 # Define patient sex and date of death
-dataset.sex = patients.sex
-dataset.dod = patients.date_of_death
+sex = patients.sex
+dod = patients.date_of_death
 
 # Define patient address: MSOA, rural-urban and IMD rank, using latest data for each patient
 latest_address_per_patient = addresses.sort_by(addresses.start_date).last_for_patient()
 imd_rounded = latest_address_per_patient.imd_rounded
-dataset.imd_quintile = case(
+imd_quintile = case(
     when((imd_rounded >= 0) & (imd_rounded < int(32844 * 1 / 5))).then("1"),
     when(imd_rounded < int(32844 * 2 / 5)).then("2"),
     when(imd_rounded < int(32844 * 3 / 5)).then("3"),
@@ -103,7 +93,7 @@ dataset.imd_quintile = case(
 # Define patient ethnicity
 latest_ethnicity_code = (
     clinical_events.where(clinical_events.snomedct_code.is_in(ethnicity_codelist))
-    .where(clinical_events.date.is_on_or_before(end_date))
+    .where(clinical_events.date.is_on_or_before(INTERVAL.end_date))
     .sort_by(clinical_events.date)
     .last_for_patient()
     .snomedct_code
@@ -112,7 +102,7 @@ latest_ethnicity_code = (
 latest_ethnicity = latest_ethnicity_code.to_category(ethnicity_codelist)
 
 # Convert ethnicity group numbers into strings
-dataset.ethnicity = case(
+ethnicity = case(
     when(latest_ethnicity == "1").then("White"),
     when(latest_ethnicity == "2").then("Mixed"),
     when(latest_ethnicity == "3").then("Asian or Asian British"),
@@ -122,4 +112,25 @@ dataset.ethnicity = case(
 )
 
 # Define population to be registered and above 18 years old
-dataset.define_population(has_registration & (dataset.age > 18))
+denominator = (has_registration & (age > 18))
+
+# Define measure
+measures.define_measure(
+    name="virtual_consultations",
+    numerator=has_virtual_consultation,
+    denominator=denominator,
+    group_by={
+        "age_greater_equal_65": age_greater_equal_65
+    },
+    intervals=months(6).starting_on("2020-04-01"),
+)
+
+measures.define_measure(
+    name="appointments",
+    numerator=has_appointment,
+    denominator=denominator,
+    group_by={
+        "age_greater_equal_65": age_greater_equal_65
+    },
+    intervals=months(6).starting_on("2020-04-01"),
+)

--- a/analysis/measures_definition.py
+++ b/analysis/measures_definition.py
@@ -43,6 +43,23 @@ last_virtual_consultation_code = (
     .snomedct_code
 )
 
+# f2f (face to face) consultations identified through clinical codes
+has_f2f_consultation = selected_events.where(
+    clinical_events.snomedct_code.is_in(f2f_consultation)
+).exists_for_patient()
+
+# Count number of f2f that a patient had
+count_f2f_consultation = selected_events.where(
+    clinical_events.snomedct_code.is_in(virtual_consultation)
+).count_for_patient()
+
+last_f2f_consultation_code = (
+    selected_events.where(clinical_events.snomedct_code.is_in(f2f_consultation))
+    .sort_by(clinical_events.date)
+    .last_for_patient()
+    .snomedct_code
+)
+
 # Appointments identified through the appointments table
 # Get all appointments with a seen date
 appointments_with_seen_date = appointments.where(
@@ -118,6 +135,16 @@ denominator = (has_registration & (age > 18))
 measures.define_measure(
     name="virtual_consultations",
     numerator=has_virtual_consultation,
+    denominator=denominator,
+    group_by={
+        "age_greater_equal_65": age_greater_equal_65
+    },
+    intervals=months(6).starting_on("2020-04-01"),
+)
+
+measures.define_measure(
+    name="f2f_consultations",
+    numerator=has_f2f_consultation,
     denominator=denominator,
     group_by={
         "age_greater_equal_65": age_greater_equal_65

--- a/project.yaml
+++ b/project.yaml
@@ -29,13 +29,22 @@ actions:
       highly_sensitive:
         study_population: output/consultation_dataset_2020-04-01_to_2021-03-31.arrow
 
-  summarise_consultation_datasets:
+  generate_consultation_measures:
     run: >
-      r:latest analysis/summarise_consultation_dataset.R
-    needs: [generate_consultation_dataset_2019-04-01_to_2020-03-31, generate_consultation_dataset_2020-04-01_to_2021-03-31]
+      ehrql:v0
+        generate-measures analysis/measures_definition.py
+        --output output/measures/consultation_measures.csv
     outputs:
-      moderately_sensitive:
-        measure_csv: output/data/summary_consultation_dataset.csv
+      highly_sensitive:
+        study_population: output/measures/consultation_measures.csv
+
+  # summarise_consultation_datasets:
+  #   run: >
+  #     r:latest analysis/summarise_consultation_dataset.R
+  #   needs: [generate_consultation_dataset_2019-04-01_to_2020-03-31, generate_consultation_dataset_2020-04-01_to_2021-03-31]
+  #   outputs:
+  #     moderately_sensitive:
+  #       measure_csv: output/data/summary_consultation_dataset.csv
 
   # summarise_consultation_codes:
   #   run: >
@@ -45,11 +54,11 @@ actions:
   #     moderately_sensitive:
   #       measure_csv: output/data/summary_consultation_codes.csv
 
-  visualise_consultation_datasets:
-    run: >
-      r:latest analysis/visualise_consultation_dataset.R
-    needs: [summarise_consultation_datasets]
-    outputs:
-      moderately_sensitive:
-        figure_n_has: output/figures/figure_n_has_consultation_by_age.png
-        figure_n_sum: output/figures/figure_n_sum_consultation_by_age.png
+  # visualise_consultation_datasets:
+  #   run: >
+  #     r:latest analysis/visualise_consultation_dataset.R
+  #   needs: [summarise_consultation_datasets]
+  #   outputs:
+  #     moderately_sensitive:
+  #       figure_n_has: output/figures/figure_n_has_consultation_by_age.png
+  #       figure_n_sum: output/figures/figure_n_sum_consultation_by_age.png

--- a/project.yaml
+++ b/project.yaml
@@ -5,84 +5,34 @@ expectations:
 
 actions:
 
-  generate_consultation_dataset_2019-04-01_to_2019-04-30:
+  generate_consultation_dataset_2019-04-01_to_2020-03-31:
     run: >
       ehrql:v0
         generate-dataset analysis/dataset_definition.py
-        --output output/consultation_dataset_2019-04-01_to_2019-04-30.arrow
+        --output output/consultation_dataset_2019-04-01_to_2020-03-31.arrow
         --
         --start-date "2019-04-01"
-        --end-date "2019-04-30"
+        --end-date "2020-03-31"
     outputs:
       highly_sensitive:
-        study_population: output/consultation_dataset_2019-04-01_to_2019-04-30.arrow
+        study_population: output/consultation_dataset_2019-04-01_to_2020-03-31.arrow
 
-  generate_consultation_dataset_2019-05-01_to_2019-05-31:
+  generate_consultation_dataset_2020-04-01_to_2021-03-31:
     run: >
       ehrql:v0
         generate-dataset analysis/dataset_definition.py
-        --output output/consultation_dataset_2019-05-01_to_2019-05-31.arrow
-        --
-        --start-date "2019-05-01"
-        --end-date "2019-05-31"
-    outputs:
-      highly_sensitive:
-        study_population: output/consultation_dataset_2019-05-01_to_2019-05-31.arrow
-
-  generate_consultation_dataset_2019-06-01_to_2019-06-30:
-    run: >
-      ehrql:v0
-        generate-dataset analysis/dataset_definition.py
-        --output output/consultation_dataset_2019-06-01_to_2019-06-30.arrow
-        --
-        --start-date "2019-06-01"
-        --end-date "2019-06-30"
-    outputs:
-      highly_sensitive:
-        study_population: output/consultation_dataset_2019-06-01_to_2019-06-30.arrow   
-
-
-  generate_consultation_dataset_2020-04-01_to_2020-04-30:
-    run: >
-      ehrql:v0
-        generate-dataset analysis/dataset_definition.py
-        --output output/consultation_dataset_2020-04-01_to_2020-04-30.arrow
+        --output output/consultation_dataset_2020-04-01_to_2021-03-31.arrow
         --
         --start-date "2020-04-01"
-        --end-date "2020-04-30"
+        --end-date "2021-03-31"
     outputs:
       highly_sensitive:
-        study_population: output/consultation_dataset_2020-04-01_to_2020-04-30.arrow
+        study_population: output/consultation_dataset_2020-04-01_to_2021-03-31.arrow
 
-  generate_consultation_dataset_2020-05-01_to_2020-05-31:
-    run: >
-      ehrql:v0
-        generate-dataset analysis/dataset_definition.py
-        --output output/consultation_dataset_2020-05-01_to_2020-05-31.arrow
-        --
-        --start-date "2020-05-01"
-        --end-date "2020-05-31"
-    outputs:
-      highly_sensitive:
-        study_population: output/consultation_dataset_2020-05-01_to_2020-05-31.arrow
-
-  generate_consultation_dataset_2020-06-01_to_2020-06-30:
-    run: >
-      ehrql:v0
-        generate-dataset analysis/dataset_definition.py
-        --output output/consultation_dataset_2020-06-01_to_2020-06-30.arrow
-        --
-        --start-date "2020-06-01"
-        --end-date "2020-06-30"
-    outputs:
-      highly_sensitive:
-        study_population: output/consultation_dataset_2020-06-01_to_2020-06-30.arrow
-  
   summarise_consultation_datasets:
     run: >
       r:latest analysis/summarise_consultation_dataset.R
-    needs: [generate_consultation_dataset_2019-04-01_to_2019-04-30, generate_consultation_dataset_2019-05-01_to_2019-05-31, generate_consultation_dataset_2019-06-01_to_2019-06-30
-    , generate_consultation_dataset_2020-04-01_to_2020-04-30, generate_consultation_dataset_2020-05-01_to_2020-05-31, generate_consultation_dataset_2020-06-01_to_2020-06-30]
+    needs: [generate_consultation_dataset_2019-04-01_to_2020-03-31, generate_consultation_dataset_2020-04-01_to_2021-03-31]
     outputs:
       moderately_sensitive:
         measure_csv: output/data/summary_consultation_dataset.csv


### PR DESCRIPTION
This adds monthly measures and also includes some other small changes.
For this I created a new python file `analysis/measures_definition.py` file that matches the ehrql statements in `analysis/dataset_definition.py`. The results will appear in its own subfolder `outputs/measures` in the `consultation_measures.csv` file. Here a quick summary of changes and list of next steps:

- **Changes**:
  - Bring back f2f consultation data for data curation/exploration
  - Add `appointments.seen_date` and only include appointments with a seen data, but no longer filter by appointment status.
- **Small fixes**:
  - Update old ehrql functions
- **Next steps**:
  - [ ] Decide if the changes to appointments are appropriate (condition that appointments need to have a seen date but no longer filter by type of appointment)
  - [ ] Decide yearly intervals for `generate-dataset` actions
  - [ ] Decide monthly intervals for measures in `generate-measures` action
  - [ ] Decide what data to summarise (currently the summarise consultation R script is commented out)
  - [ ] Decide what data to visualise (also currently commented out, I'd suggest we plot the data from the measures results)
