### PR TITLE
add weekly measures

### DIFF
--- a/analysis/measures_definition.py
+++ b/analysis/measures_definition.py
@@ -73,12 +73,15 @@ has_appointment = appointments_with_seen_date.exists_for_patient()
 
 # Demographic variables and other patient characteristics
 # Define variable that checks if a patients is registered at the start date
-has_registration = practice_registrations.for_patient_on(
+registration = practice_registrations.for_patient_on(
     INTERVAL.start_date
 ).exists_for_patient()
 
 age = patients.age_on(INTERVAL.start_date)
 age_greater_equal_65 = age >= 65
+
+# Define population to be registered and above 18 years old
+has_registration = registration & (age > 18)
 
 # Define patient sex and date of death
 sex = patients.sex
@@ -117,71 +120,64 @@ ethnicity = case(
     default="missing",
 )
 
-# Define population to be registered and above 18 years old
-denominator = has_registration & (age > 18)
+# Define population denominator
+denominator = has_appointment
 
-# Define monthly measure
-measures.define_measure(
-    name="virtual_consultations_pre_monthly",
-    numerator=has_virtual_consultation,
-    denominator=denominator,
-    group_by={"age_greater_equal_65": age_greater_equal_65},
-    intervals=months(6).starting_on("2019-04-01"),
-)
+# # Define monthly measure
+# measures.define_measure(
+#     name="virtual_consultations_pre_monthly",
+#     numerator=has_virtual_consultation,
+#     denominator=denominator,
+#     group_by={"age_greater_equal_65": age_greater_equal_65},
+#     intervals=months(6).starting_on("2019-04-01"),
+# )
 
-measures.define_measure(
-    name="appointments_pre_monthly",
-    numerator=has_appointment,
-    denominator=denominator,
-    group_by={"age_greater_equal_65": age_greater_equal_65},
-    intervals=months(6).starting_on("2019-04-01"),
-)
+# measures.define_measure(
+#     name="appointments_pre_monthly",
+#     numerator=has_appointment,
+#     denominator=denominator,
+#     group_by={"age_greater_equal_65": age_greater_equal_65},
+#     intervals=months(6).starting_on("2019-04-01"),
+# )
 
-measures.define_measure(
-    name="virtual_consultations_during_monthly",
-    numerator=has_virtual_consultation,
-    denominator=denominator,
-    group_by={"age_greater_equal_65": age_greater_equal_65},
-    intervals=months(6).starting_on("2020-04-01"),
-)
+# measures.define_measure(
+#     name="virtual_consultations_during_monthly",
+#     numerator=has_virtual_consultation,
+#     denominator=denominator,
+#     group_by={"age_greater_equal_65": age_greater_equal_65},
+#     intervals=months(6).starting_on("2020-04-01"),
+# )
 
-measures.define_measure(
-    name="appointments_during_monthly",
-    numerator=has_appointment,
-    denominator=denominator,
-    group_by={"age_greater_equal_65": age_greater_equal_65},
-    intervals=months(6).starting_on("2020-04-01"),
-)
+# measures.define_measure(
+#     name="appointments_during_monthly",
+#     numerator=has_appointment,
+#     denominator=denominator,
+#     group_by={"age_greater_equal_65": age_greater_equal_65},
+#     intervals=months(6).starting_on("2020-04-01"),
+# )
 
 # Define weekly measure
-# measures.define_measure(
-#     name="virtual_consultations_pre_weekly",
-#     numerator=has_virtual_consultation,
-#     denominator=denominator,
-#     group_by={"age_greater_equal_65": age_greater_equal_65},
-#     intervals=weeks(8).starting_on("2019-04-01"),
-# )
+measures.define_measure(
+    name="virtual_consultations_pre_weekly",
+    numerator=has_virtual_consultation,
+    denominator=denominator,
+    group_by={"age_greater_equal_65": age_greater_equal_65},
+    intervals=weeks(10).starting_on("2019-04-01"),
+)
 
-# measures.define_measure(
-#     name="appointments_pre_weekly",
-#     numerator=has_appointment,
-#     denominator=denominator,
-#     group_by={"age_greater_equal_65": age_greater_equal_65},
-#     intervals=weeks(8).starting_on("2019-04-01"),
-# )
+measures.define_measure(
+    name="virtual_consultations_during_weekly_2020",
+    numerator=has_appointment,
+    denominator=denominator,
+    group_by={"age_greater_equal_65": age_greater_equal_65},
+    intervals=weeks(10).starting_on("2020-04-01"),
+)
 
-# measures.define_measure(
-#     name="virtual_consultations_during_weekly",
-#     numerator=has_virtual_consultation,
-#     denominator=denominator,
-#     group_by={"age_greater_equal_65": age_greater_equal_65},
-#     intervals=weeks(8).starting_on("2020-04-01"),
-# )
+measures.define_measure(
+    name="virtual_consultations_during_weekly_2021",
+    numerator=has_virtual_consultation,
+    denominator=denominator,
+    group_by={"age_greater_equal_65": age_greater_equal_65},
+    intervals=weeks(10).starting_on("2021-04-01"),
+)
 
-# measures.define_measure(
-#     name="appointments_during_weekly",
-#     numerator=has_appointment,
-#     denominator=denominator,
-#     group_by={"age_greater_equal_65": age_greater_equal_65},
-#     intervals=weeks(8).starting_on("2020-04-01"),
-# )

--- a/analysis/measures_definition.py
+++ b/analysis/measures_definition.py
@@ -73,15 +73,12 @@ has_appointment = appointments_with_seen_date.exists_for_patient()
 
 # Demographic variables and other patient characteristics
 # Define variable that checks if a patients is registered at the start date
-registration = practice_registrations.for_patient_on(
+has_registration = practice_registrations.for_patient_on(
     INTERVAL.start_date
 ).exists_for_patient()
 
 age = patients.age_on(INTERVAL.start_date)
 age_greater_equal_65 = age >= 65
-
-# Define population to be registered and above 18 years old
-has_registration = registration & (age > 18)
 
 # Define patient sex and date of death
 sex = patients.sex
@@ -121,7 +118,7 @@ ethnicity = case(
 )
 
 # Define population denominator
-denominator = has_appointment
+denominator = has_registration & (age > 18) & has_appointment
 
 # # Define monthly measure
 # measures.define_measure(

--- a/project.yaml
+++ b/project.yaml
@@ -14,7 +14,7 @@ actions:
         --start-date "2019-04-01"
         --end-date "2020-03-31"
     outputs:
-      highly_sensitive:
+      highlyly_sensitive:
         study_population: output/consultation_dataset_2019-04-01_to_2020-03-31.arrow
 
   generate_consultation_dataset_2020-04-01_to_2021-03-31:
@@ -28,6 +28,18 @@ actions:
     outputs:
       highly_sensitive:
         study_population: output/consultation_dataset_2020-04-01_to_2021-03-31.arrow
+
+  generate_consultation_dataset_2021-04-01_to_2022-03-31:
+    run: >
+      ehrql:v0
+        generate-dataset analysis/dataset_definition.py
+        --output output/consultation_dataset_2021-04-01_to_2022-03-31.arrow
+        --
+        --start-date "2021-04-01"
+        --end-date "2022-03-31"
+    outputs:
+      highly_sensitive:
+        study_population: output/consultation_dataset_2021-04-01_to_2022-03-31.arrow
 
   generate_consultation_measures:
     run: >

--- a/project.yaml
+++ b/project.yaml
@@ -14,7 +14,7 @@ actions:
         --start-date "2019-04-01"
         --end-date "2020-03-31"
     outputs:
-      highlyly_sensitive:
+      highly_sensitive:
         study_population: output/consultation_dataset_2019-04-01_to_2020-03-31.arrow
 
   generate_consultation_dataset_2020-04-01_to_2021-03-31:


### PR DESCRIPTION
This pull request is meant to look at weekly virtual consultation in three years (2019, 2020 and 2021) starting from 1st of April of each year. We have adjusted the denominator to be has_appointment because we are interested in the ratio of virtual of the appointment instead of registration. 
1. Change in denominator
2. three virtual consultation measures (2019, 2020 and 2021)
3. three generate dataset curation (2019, 2020 and 2021)