### PR TITLE
Remove other categories of appointment

### DIFF
--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -76,14 +76,7 @@ appointments_with_seen_date = appointments.where(
     appointments.seen_date <= end_date
 ).where(
     appointments.status.is_in(
-        [
-            "Arrived",
-            "In Progress",
-            "Finished",
-            "Visit",
-            "Waiting",
-            "Patient Walked Out",
-        ]
+        ["Finished"]
     )
 )
 


### PR DESCRIPTION
This is to remove other categories of appointments from the dataset definition file  because we are only interested in the 'finished' appointments.