### PR TITLE
Add `group_by` to measures

### DIFF
--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -71,19 +71,13 @@ dataset.last_f2f_consultation_code = (
 )
 
 # Appointments identified through the appointments table
-# Get all appointments with a seen date
-appointments_with_seen_date = appointments.where(
-    appointments.seen_date <= end_date
-).where(
-    appointments.status.is_in(
-        ["Finished"]
-    )
-)
+# Get all appointments with status "Finished"
+appointments_finished = appointments.where(appointments.status.is_in(["Finished"]))
 
-# Count number of appointments with a seen date in the time period
-dataset.count_appointment = appointments_with_seen_date.count_for_patient()
-# Specify if a patient had (True/False) an appointment with a seen date
-dataset.has_appointment = appointments_with_seen_date.exists_for_patient()
+# Count number of finished appointments in the time period
+dataset.count_appointment = appointments_finished.count_for_patient()
+# Specify if a patient had (True/False) a finished appointment in the time period
+dataset.has_appointment = appointments_finished.exists_for_patient()
 
 # Demographic variables and other patient characteristics
 # Define variable that checks if a patients is registered at the start date

--- a/analysis/dataset_definition.py
+++ b/analysis/dataset_definition.py
@@ -2,7 +2,7 @@ from argparse import ArgumentParser
 import datetime
 from ehrql import create_dataset, case, when
 
-from ehrql.tables.beta.tpp import (
+from ehrql.tables.tpp import (
     clinical_events,
     patients,
     practice_registrations,
@@ -107,7 +107,7 @@ dataset.imd_quintile = case(
     when(imd_rounded < int(32844 * 3 / 5)).then("3"),
     when(imd_rounded < int(32844 * 4 / 5)).then("4"),
     when(imd_rounded < int(32844 * 5 / 5)).then("5"),
-    default="Missing",
+    otherwise="Missing",
 )
 
 # Define patient ethnicity
@@ -128,7 +128,7 @@ dataset.ethnicity = case(
     when(latest_ethnicity == "3").then("Asian or Asian British"),
     when(latest_ethnicity == "4").then("Black or Black British"),
     when(latest_ethnicity == "5").then("Chinese or Other Ethnic Groups"),
-    default="missing",
+    otherwise="missing",
 )
 
 # Define population to be registered and above 18 years old

--- a/analysis/measures_definition.py
+++ b/analysis/measures_definition.py
@@ -1,6 +1,6 @@
 from ehrql import INTERVAL, create_measures, case, when, months, weeks
 
-from ehrql.tables.beta.tpp import (
+from ehrql.tables.tpp import (
     clinical_events,
     patients,
     practice_registrations,
@@ -93,7 +93,7 @@ imd_quintile = case(
     when(imd_rounded < int(32844 * 3 / 5)).then("3"),
     when(imd_rounded < int(32844 * 4 / 5)).then("4"),
     when(imd_rounded < int(32844 * 5 / 5)).then("5"),
-    default="Missing",
+    otherwise="Missing",
 )
 
 # Define patient ethnicity
@@ -114,7 +114,7 @@ ethnicity = case(
     when(latest_ethnicity == "3").then("Asian or Asian British"),
     when(latest_ethnicity == "4").then("Black or Black British"),
     when(latest_ethnicity == "5").then("Chinese or Other Ethnic Groups"),
-    default="missing",
+    otherwise="missing",
 )
 
 # Define population denominator

--- a/analysis/measures_definition.py
+++ b/analysis/measures_definition.py
@@ -61,15 +61,13 @@ last_f2f_consultation_code = (
 )
 
 # Appointments identified through the appointments table
-# Get all appointments with a seen date
-appointments_with_seen_date = appointments.where(
-    appointments.seen_date <= INTERVAL.end_date,
-).where(appointments.status.is_in(["Finished"]))
+# Get all appointments with status "Finished"
+appointments_finished = appointments.where(appointments.status.is_in(["Finished"]))
 
-# Count number of appointments with a seen date in the time period
-count_appointment = appointments_with_seen_date.count_for_patient()
-# Specify if a patient had (True/False) an appointment with a seen date
-has_appointment = appointments_with_seen_date.exists_for_patient()
+# Count number of finished appointments in the time period
+count_appointment = appointments_finished.count_for_patient()
+# Specify if a patient had (True/False) a finished appointments in the time period
+has_appointment = appointments_finished.exists_for_patient()
 
 # Demographic variables and other patient characteristics
 # Define variable that checks if a patients is registered at the start date
@@ -177,4 +175,3 @@ measures.define_measure(
     group_by={"age_greater_equal_65": age_greater_equal_65},
     intervals=weeks(10).starting_on("2021-04-01"),
 )
-

--- a/analysis/measures_definition.py
+++ b/analysis/measures_definition.py
@@ -118,60 +118,46 @@ ethnicity = case(
 # Define population denominator
 denominator = has_registration & (age > 18) & has_appointment
 
-# # Define monthly measure
-# measures.define_measure(
-#     name="virtual_consultations_pre_monthly",
-#     numerator=has_virtual_consultation,
-#     denominator=denominator,
-#     group_by={"age_greater_equal_65": age_greater_equal_65},
-#     intervals=months(6).starting_on("2019-04-01"),
-# )
+# Specify description and start dates for measures
+measures_start_dates = {
+    "pre2019": "2019-04-01",
+    "during2020": "2020-04-01",
+    "during2021": "2021-04-01",
+}
 
-# measures.define_measure(
-#     name="appointments_pre_monthly",
-#     numerator=has_appointment,
-#     denominator=denominator,
-#     group_by={"age_greater_equal_65": age_greater_equal_65},
-#     intervals=months(6).starting_on("2019-04-01"),
-# )
+# Iterate through the start dates in measures_start_dates and
+# calculate measures for each age sex/ethnicity/imd pair
+for time_description, start_date in measures_start_dates.items():
 
-# measures.define_measure(
-#     name="virtual_consultations_during_monthly",
-#     numerator=has_virtual_consultation,
-#     denominator=denominator,
-#     group_by={"age_greater_equal_65": age_greater_equal_65},
-#     intervals=months(6).starting_on("2020-04-01"),
-# )
+    measures.define_measure(
+        name=f"virtual_{time_description}_weekly_age_sex",
+        numerator=has_virtual_consultation,
+        denominator=denominator,
+        group_by={
+            "age_greater_equal_65": age_greater_equal_65,
+            "sex": sex,
+        },
+        intervals=weeks(10).starting_on(start_date),
+    )
 
-# measures.define_measure(
-#     name="appointments_during_monthly",
-#     numerator=has_appointment,
-#     denominator=denominator,
-#     group_by={"age_greater_equal_65": age_greater_equal_65},
-#     intervals=months(6).starting_on("2020-04-01"),
-# )
+    measures.define_measure(
+        name=f"virtual_{time_description}_weekly_age_ethnicity",
+        numerator=has_virtual_consultation,
+        denominator=denominator,
+        group_by={
+            "age_greater_equal_65": age_greater_equal_65,
+            "ethnicity": ethnicity,
+        },
+        intervals=weeks(10).starting_on(start_date),
+    )
 
-# Define weekly measure
-measures.define_measure(
-    name="virtual_consultations_pre_weekly",
-    numerator=has_virtual_consultation,
-    denominator=denominator,
-    group_by={"age_greater_equal_65": age_greater_equal_65},
-    intervals=weeks(10).starting_on("2019-04-01"),
-)
-
-measures.define_measure(
-    name="virtual_consultations_during_weekly_2020",
-    numerator=has_virtual_consultation,
-    denominator=denominator,
-    group_by={"age_greater_equal_65": age_greater_equal_65},
-    intervals=weeks(10).starting_on("2020-04-01"),
-)
-
-measures.define_measure(
-    name="virtual_consultations_during_weekly_2021",
-    numerator=has_virtual_consultation,
-    denominator=denominator,
-    group_by={"age_greater_equal_65": age_greater_equal_65},
-    intervals=weeks(10).starting_on("2021-04-01"),
-)
+    measures.define_measure(
+        name=f"virtual_{time_description}_weekly_age_imd",
+        numerator=has_virtual_consultation,
+        denominator=denominator,
+        group_by={
+            "age_greater_equal_65": age_greater_equal_65,
+            "imd_quintile": imd_quintile,
+        },
+        intervals=weeks(10).starting_on(start_date),
+    )

--- a/project.yaml
+++ b/project.yaml
@@ -7,7 +7,7 @@ actions:
 
   generate_consultation_dataset_2019-04-01_to_2020-03-31:
     run: >
-      ehrql:v0
+      ehrql:v1
         generate-dataset analysis/dataset_definition.py
         --output output/consultation_dataset_2019-04-01_to_2020-03-31.arrow
         --
@@ -19,7 +19,7 @@ actions:
 
   generate_consultation_dataset_2020-04-01_to_2021-03-31:
     run: >
-      ehrql:v0
+      ehrql:v1
         generate-dataset analysis/dataset_definition.py
         --output output/consultation_dataset_2020-04-01_to_2021-03-31.arrow
         --
@@ -31,7 +31,7 @@ actions:
 
   generate_consultation_dataset_2021-04-01_to_2022-03-31:
     run: >
-      ehrql:v0
+      ehrql:v1
         generate-dataset analysis/dataset_definition.py
         --output output/consultation_dataset_2021-04-01_to_2022-03-31.arrow
         --
@@ -43,7 +43,7 @@ actions:
 
   generate_consultation_measures:
     run: >
-      ehrql:v0
+      ehrql:v1
         generate-measures analysis/measures_definition.py
         --output output/measures/consultation_measures.csv
     outputs:


### PR DESCRIPTION
This calculate 10 weekly measures for each `age_greater_equal_65` - `sex`/`ethnicity`/`imd` pair over three time periods defined in `measures_start_dates`.

@AbodunrinAminu-Manchester in your initial code in PR https://github.com/opensafely/digital-access-to-primary-care/pull/41 it looks like you added only one variable for each `group_by`. I wondered if you actually want to always group by `age_greater_equal_65` and one other variable?
